### PR TITLE
fix: update Algorand SDK and improve note decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.env
+.env.local
+.env.production
+.env.development
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json

--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -12,6 +12,11 @@ function encodeNote(data) {
 
 // Convert base64 string to Uint8Array
 function base64ToUint8Array(b64) {
+  if (typeof Buffer !== 'undefined') {
+    // Node.js environment
+    return Uint8Array.from(Buffer.from(b64, 'base64'));
+  }
+  // Browser fallback
   const bin = atob(b64);
   const arr = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "algosdk": "^2.11.0",
+    "algosdk": "^3.0.0",
     "tweetnacl": "^1.0.3",
-    "@perawallet/connect": "^1.2.3"
+    "@perawallet/connect": "^1.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",


### PR DESCRIPTION
## Summary
- upgrade Algorand SDK to v3 to satisfy wallet dependency
- decode base64 notes with a Node.js fallback
- add gitignore for common Node artifacts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68956a5ff1e083248e1a08a5cbdf38d2