### PR TITLE
Add default Algorand RPC endpoints and handle fetch errors

### DIFF
--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -1,5 +1,13 @@
 import algosdk from 'algosdk';
 
+// Default RPC endpoints for Algod and the Indexer. These can be overridden
+// by providing NEXT_PUBLIC_ALGOD_RPC or NEXT_PUBLIC_INDEXER_RPC environment
+// variables when running the app.
+const ALGOD_RPC =
+  process.env.NEXT_PUBLIC_ALGOD_RPC || 'https://testnet-api.algonode.cloud';
+const INDEXER_RPC =
+  process.env.NEXT_PUBLIC_INDEXER_RPC || 'https://testnet-idx.algonode.cloud';
+
 // Prefix "EDEN" encoded as bytes for filtering
 const EDEN_PREFIX = new Uint8Array([0x45, 0x44, 0x45, 0x4e]);
 
@@ -43,7 +51,8 @@ function decodeNote(b64) {
  * @param {Object} opts.gps An object with `lat` and `lon` numbers
  */
 export async function tossAPod({ walletConnector, gps }) {
-  const algod = new algosdk.Algodv2('', process.env.NEXT_PUBLIC_ALGOD_RPC);
+  // Use configured Algod endpoint (defaults to Algonode's testnet instance)
+  const algod = new algosdk.Algodv2('', ALGOD_RPC);
   // Determine the connected account
   let account;
   if (walletConnector.getAccounts) {
@@ -74,18 +83,25 @@ export async function tossAPod({ walletConnector, gps }) {
  * @returns {Array} Array of pod objects with dateString and decoded data
  */
 export async function fetchMyPods({ address }) {
-  const indexer = new algosdk.Indexer('', process.env.NEXT_PUBLIC_INDEXER_RPC);
-  const res = await indexer
-    .searchForTransactions()
-    .address(address)
-    .notePrefix(EDEN_PREFIX)
-    .do();
-  const txs = res.transactions || [];
-  return txs.map((tx) => {
-    const decoded = decodeNote(tx.note);
-    return {
-      dateString: new Date(tx['round-time'] * 1000).toLocaleString(),
-      ...decoded,
-    };
-  });
+  const indexer = new algosdk.Indexer('', INDEXER_RPC);
+  try {
+    const res = await indexer
+      .searchForTransactions()
+      .address(address)
+      .notePrefix(EDEN_PREFIX)
+      .do();
+    const txs = res.transactions || [];
+    return txs.map((tx) => {
+      const decoded = decodeNote(tx.note);
+      return {
+        dateString: new Date(tx['round-time'] * 1000).toLocaleString(),
+        ...decoded,
+      };
+    });
+  } catch (err) {
+    // Network errors are common if the RPC endpoint is unreachable.
+    // Log and return an empty list instead of throwing so the UI can recover.
+    console.error('Failed to fetch pods', err);
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- supply default Algod and Indexer RPC URLs if environment variables are missing
- wrap indexer lookup in try/catch to log failures and avoid crashing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689571e1b30483249c7ec042f71f5e12