### PR TITLE
Proxy Algorand indexer requests through API route

### DIFF
--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -83,6 +83,23 @@ export async function tossAPod({ walletConnector, gps }) {
  * @returns {Array} Array of pod objects with dateString and decoded data
  */
 export async function fetchMyPods({ address }) {
+  // If running in the browser, hit the Next.js API route so we can
+  // avoid CORS issues when the public indexer endpoint disallows
+  // direct requests from the client. The API route performs the
+  // same query from the server side where CORS is not a problem.
+  if (typeof window !== 'undefined') {
+    try {
+      const res = await fetch(
+        `/api/pods?address=${encodeURIComponent(address)}`
+      );
+      if (!res.ok) throw new Error('Request failed');
+      return await res.json();
+    } catch (err) {
+      console.error('Failed to fetch pods', err);
+      return [];
+    }
+  }
+
   const indexer = new algosdk.Indexer('', INDEXER_RPC);
   try {
     const res = await indexer

--- a/pages/api/pods.js
+++ b/pages/api/pods.js
@@ -1,0 +1,15 @@
+import { fetchMyPods } from '../../lib/eden-sdk';
+
+// Simple proxy endpoint that queries the Algorand indexer on the
+// server side so that the front-end can avoid CORS restrictions.
+export default async function handler(req, res) {
+  const { address } = req.query;
+  if (!address) {
+    res.status(400).json({ error: 'Missing address' });
+    return;
+  }
+
+  const pods = await fetchMyPods({ address });
+  res.status(200).json(pods);
+}
+


### PR DESCRIPTION
## Summary
- Add environment-aware logic to `fetchMyPods` that proxies browser requests through a Next.js API route to avoid CORS errors
- Introduce `/api/pods` server endpoint which queries the Algorand indexer and returns pod data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689573ce4b6c8324a447783b9df25fd6