### PR TITLE
Fix wallet reconnection loop when tossing a pod

### DIFF
--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -49,24 +49,24 @@ function decodeNote(b64) {
  * @param {Object} opts
  * @param {Object} opts.walletConnector Wallet connection (Pera Wallet instance)
  * @param {Object} opts.gps An object with `lat` and `lon` numbers
+ * @param {string} [opts.account] Optional account address to use for the transaction
  */
-export async function tossAPod({ walletConnector, gps }) {
+export async function tossAPod({ walletConnector, gps, account }) {
   // Use configured Algod endpoint (defaults to Algonode's testnet instance)
   const algod = new algosdk.Algodv2('', ALGOD_RPC);
-  // Determine the connected account
-  let account;
-  if (walletConnector.getAccounts) {
-    const accounts = await walletConnector.getAccounts();
-    account = accounts[0];
-  } else if (walletConnector.connect) {
-    const accounts = await walletConnector.connect();
-    account = accounts[0];
+  // Determine the connected account without forcing a reconnect
+  const sender =
+    account ||
+    (walletConnector?.connector?.accounts &&
+      walletConnector.connector.accounts[0]);
+  if (!sender) {
+    throw new Error('No connected account');
   }
   const params = await algod.getTransactionParams().do();
   const note = encodeNote({ gps, t: Date.now() });
   const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
-    from: account,
-    to: account,
+    from: sender,
+    to: sender,
     amount: 0,
     note,
     suggestedParams: params,

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,7 +50,7 @@ export default function Home() {
           err => reject(err)
         );
       });
-      await tossAPod({ walletConnector: peraWallet, gps });
+      await tossAPod({ walletConnector: peraWallet, gps, account });
       const list = await fetchMyPods({ address: account });
       setPods(list);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Avoid forcing wallet reconnection when tossing a pod by reusing the connected account
- Update frontend to pass the active account to the toss operation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689578b45e1c8324a7fc6afc830eabcb