### PR TITLE
Fix account handling for pod transactions

### DIFF
--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -54,12 +54,15 @@ function decodeNote(b64) {
 export async function tossAPod({ walletConnector, gps, account }) {
   // Use configured Algod endpoint (defaults to Algonode's testnet instance)
   const algod = new algosdk.Algodv2('', ALGOD_RPC);
-  // Determine the connected account without forcing a reconnect
+  // Determine the connected account without forcing a reconnect.
+  // `account` may be provided as a string address or as an object with an
+  // `address` field depending on the wallet connector. Fallback to the first
+  // account reported by the connector if none was supplied.
+  const senderRaw =
+    account ?? walletConnector?.connector?.accounts?.[0];
   const sender =
-    account ||
-    (walletConnector?.connector?.accounts &&
-      walletConnector.connector.accounts[0]);
-  if (!sender) {
+    typeof senderRaw === 'object' ? senderRaw?.address : senderRaw;
+  if (typeof sender !== 'string' || sender.length === 0) {
     throw new Error('No connected account');
   }
   const params = await algod.getTransactionParams().do();

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,7 +13,11 @@ export default function Home() {
       const wallet = new PeraWalletConnect();
       const accounts = await wallet.reconnectSession();
       if (accounts && accounts.length) {
-        setAccount(accounts[0]);
+        // Pera Wallet may return either a plain address string or an object
+        // containing the address. Normalize to a string for downstream use.
+        const addr =
+          typeof accounts[0] === 'object' ? accounts[0].address : accounts[0];
+        setAccount(addr);
       }
       setPeraWallet(wallet);
     }
@@ -32,7 +36,9 @@ export default function Home() {
   async function connectWallet() {
     if (!peraWallet) return;
     const accounts = await peraWallet.connect();
-    setAccount(accounts[0]);
+    const addr =
+      typeof accounts[0] === 'object' ? accounts[0].address : accounts[0];
+    setAccount(addr);
   }
 
   async function handleToss() {


### PR DESCRIPTION
## Summary
- normalize account input from Pera Wallet to a plain address before building transactions
- handle object-form accounts when reconnecting/connecting wallet

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68957d9116e88324b2a24ce045e7be05