### PR TITLE
Handle missing or object-based account addresses

### DIFF
--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -55,14 +55,20 @@ export async function tossAPod({ walletConnector, gps, account }) {
   // Use configured Algod endpoint (defaults to Algonode's testnet instance)
   const algod = new algosdk.Algodv2('', ALGOD_RPC);
   // Determine the connected account without forcing a reconnect.
-  // `account` may be provided as a string address or as an object with an
-  // `address` field depending on the wallet connector. Fallback to the first
-  // account reported by the connector if none was supplied.
+  // Wallet connectors may expose the selected account in a few different
+  // shapes (plain string or object with an `address` field) and under
+  // different properties. Normalise those possibilities into a string and
+  // fall back to the first account reported by the connector if one isn't
+  // explicitly provided.
   const senderRaw =
-    account ?? walletConnector?.connector?.accounts?.[0];
+    account ??
+    walletConnector?.connector?.accounts?.[0] ??
+    walletConnector?.accounts?.[0];
   const sender =
     typeof senderRaw === 'object' ? senderRaw?.address : senderRaw;
   if (typeof sender !== 'string' || sender.length === 0) {
+    // Surface a clear error rather than letting algosdk throw an obscure
+    // "Address must not be null or undefined" exception.
     throw new Error('No connected account');
   }
   const params = await algod.getTransactionParams().do();
@@ -74,7 +80,9 @@ export async function tossAPod({ walletConnector, gps, account }) {
     note,
     suggestedParams: params,
   });
-  const signed = await walletConnector.signTransaction([txn]);
+  // Pera Wallet returns an array of signed transactions. We only submit the
+  // single transaction we created above.
+  const [signed] = await walletConnector.signTransaction([txn]);
   const send = await algod.sendRawTransaction(signed.blob || signed).do();
   return send.txId;
 }


### PR DESCRIPTION
## Summary
- normalize account address lookups for wallet connectors
- clarify error when no account is connected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895819954ac832488dd33dbaa6a341a