### PR TITLE
Improve wallet connection handling and debug logs

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -12,6 +12,9 @@ export default function Home() {
       const { PeraWalletConnect } = await import('@perawallet/connect');
       const wallet = new PeraWalletConnect();
       const accounts = await wallet.reconnectSession();
+      console.log('Accounts from reconnectSession:', accounts);
+      console.log('wallet.accounts after reconnect:', wallet.accounts);
+      console.log('wallet.connector.accounts after reconnect:', wallet.connector?.accounts);
       if (accounts && accounts.length) {
         // Pera Wallet may return either a plain address string or an object
         // containing the address. Normalize to a string for downstream use.
@@ -135,113 +138,32 @@ async function handleToss() {
 // Also update your connectWallet function with better debugging
 async function connectWallet() {
   if (!peraWallet) return;
-  
+
   try {
     console.log('Connecting wallet...');
     const accounts = await peraWallet.connect();
     console.log('Raw accounts from connect:', accounts);
-    
+    console.log('peraWallet.accounts after connect:', peraWallet.accounts);
+    console.log('peraWallet.connector?.accounts after connect:', peraWallet.connector?.accounts);
+
     if (!accounts || accounts.length === 0) {
       throw new Error('No accounts returned from wallet');
     }
-    
+
     const addr = typeof accounts[0] === 'object' ? accounts[0].address : accounts[0];
     console.log('Extracted address:', addr);
-    
+
     if (!addr || typeof addr !== 'string') {
       throw new Error('Invalid account format received from wallet');
     }
-    
+
     setAccount(addr);
     console.log('Account set successfully:', addr);
-    
+    setTimeout(debugWalletState, 0);
+
   } catch (err) {
     console.error('Wallet connection error:', err);
     alert('Failed to connect wallet: ' + err.message);
-  }
-}
-
-  async function handleToss() {
-  if (!peraWallet || !account) {
-    alert('Wallet not connected properly');
-    return;
-  }
-  
-  setLoading(true);
-  
-  try {
-    console.log('Getting location...');
-    
-    // Add timeout and better error handling for geolocation
-    const gps = await new Promise((resolve, reject) => {
-      if (!navigator.geolocation) {
-        reject(new Error('Geolocation not supported'));
-        return;
-      }
-      
-      const timeout = setTimeout(() => {
-        reject(new Error('Location request timed out'));
-      }, 10000); // 10 second timeout
-      
-      navigator.geolocation.getCurrentPosition(
-        pos => {
-          clearTimeout(timeout);
-          console.log('Got location:', pos.coords.latitude, pos.coords.longitude);
-          resolve({
-            lat: pos.coords.latitude,
-            lon: pos.coords.longitude
-          });
-        },
-        err => {
-          clearTimeout(timeout);
-          console.error('Geolocation error:', err);
-          reject(new Error(`Location error: ${err.message}`));
-        },
-        {
-          enableHighAccuracy: true,
-          timeout: 8000,
-          maximumAge: 300000 // 5 minutes
-        }
-      );
-    });
-
-    console.log('Creating transaction...');
-    console.log('Account:', account);
-    console.log('GPS:', gps);
-    
-    const txId = await tossAPod({ 
-      walletConnector: peraWallet, 
-      gps, 
-      account 
-    });
-    
-    console.log('Transaction successful:', txId);
-    alert(`Pod tossed! Transaction: ${txId}`);
-    
-    // Refresh pods list
-    const list = await fetchMyPods({ address: account });
-    setPods(list);
-    
-  } catch (err) {
-    console.error('Full error:', err);
-    
-    // Show user-friendly error messages
-    let errorMessage = 'Failed to toss pod: ';
-    
-    if (err.message.includes('Location') || err.message.includes('geolocation')) {
-      errorMessage += 'Could not access your location. Please enable location permissions and try again.';
-    } else if (err.message.includes('User rejected')) {
-      errorMessage += 'Transaction was cancelled.';
-    } else if (err.message.includes('No connected account')) {
-      errorMessage += 'Wallet connection lost. Please reconnect.';
-    } else {
-      errorMessage += err.message || 'Unknown error occurred.';
-    }
-    
-    alert(errorMessage);
-    
-  } finally {
-    setLoading(false);
   }
 }
 


### PR DESCRIPTION
## Summary
- log wallet and connector accounts during reconnect and connect
- invoke debug wallet state after connection
- remove duplicated toss handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895898474b08324a008325e96c7fc4f