### PR TITLE
Allow tossing pod without GPS

### DIFF
--- a/lib/eden-sdk.js
+++ b/lib/eden-sdk.js
@@ -44,14 +44,14 @@ function decodeNote(b64) {
 }
 
 /**
- * Send a zero-Algo self transaction with encrypted GPS data on chain.
+ * Send a zero-Algo self transaction with optional GPS data on chain.
  * Uses the provided walletConnector to sign the transaction.
  * @param {Object} opts
  * @param {Object} opts.walletConnector Wallet connection (Pera Wallet instance)
- * @param {Object} opts.gps An object with `lat` and `lon` numbers
  * @param {string} opts.account Algorand address to use for the transaction
+ * @param {Object} [opts.gps] Optional object with `lat` and `lon` numbers
  */
-export async function tossAPod({ walletConnector, gps, account }) {
+export async function tossAPod({ walletConnector, account, gps }) {
   if (!walletConnector) {
     throw new Error('Wallet connector not provided');
   }
@@ -64,7 +64,9 @@ export async function tossAPod({ walletConnector, gps, account }) {
   const algod = new algosdk.Algodv2('', ALGOD_RPC);
 
   const params = await algod.getTransactionParams().do();
-  const note = encodeNote({ gps, t: Date.now() });
+  const noteData = { t: Date.now() };
+  if (gps) noteData.gps = gps;
+  const note = encodeNote(noteData);
 
   const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: account,

--- a/pages/index.js
+++ b/pages/index.js
@@ -47,91 +47,6 @@ function debugWalletState() {
   console.log('========================');
 }
 
-// Updated handleToss function with better debugging
-async function handleToss() {
-  if (!peraWallet || !account) {
-    alert('Wallet not connected properly');
-    return;
-  }
-  
-  setLoading(true);
-  
-  try {
-    console.log('Getting location...');
-    
-    // Add timeout and better error handling for geolocation
-    const gps = await new Promise((resolve, reject) => {
-      if (!navigator.geolocation) {
-        reject(new Error('Geolocation not supported'));
-        return;
-      }
-      
-      const timeout = setTimeout(() => {
-        reject(new Error('Location request timed out'));
-      }, 10000); // 10 second timeout
-      
-      navigator.geolocation.getCurrentPosition(
-        pos => {
-          clearTimeout(timeout);
-          console.log('Got location:', pos.coords.latitude, pos.coords.longitude);
-          resolve({
-            lat: pos.coords.latitude,
-            lon: pos.coords.longitude
-          });
-        },
-        err => {
-          clearTimeout(timeout);
-          console.error('Geolocation error:', err);
-          reject(new Error(`Location error: ${err.message}`));
-        },
-        {
-          enableHighAccuracy: true,
-          timeout: 8000,
-          maximumAge: 300000 // 5 minutes
-        }
-      );
-    });
-
-    console.log('Creating transaction...');
-    console.log('Account:', account);
-    console.log('GPS:', gps);
-    
-    const txId = await tossAPod({ 
-      walletConnector: peraWallet, 
-      gps, 
-      account 
-    });
-    
-    console.log('Transaction successful:', txId);
-    alert(`Pod tossed! Transaction: ${txId}`);
-    
-    // Refresh pods list
-    const list = await fetchMyPods({ address: account });
-    setPods(list);
-    
-  } catch (err) {
-    console.error('Full error:', err);
-    
-    // Show user-friendly error messages
-    let errorMessage = 'Failed to toss pod: ';
-    
-    if (err.message.includes('Location') || err.message.includes('geolocation')) {
-      errorMessage += 'Could not access your location. Please enable location permissions and try again.';
-    } else if (err.message.includes('User rejected')) {
-      errorMessage += 'Transaction was cancelled.';
-    } else if (err.message.includes('No connected account')) {
-      errorMessage += 'Wallet connection lost. Please reconnect.';
-    } else {
-      errorMessage += err.message || 'Unknown error occurred.';
-    }
-    
-    alert(errorMessage);
-    
-  } finally {
-    setLoading(false);
-  }
-}
-
 // Also update your connectWallet function with better debugging
 async function connectWallet() {
   if (!peraWallet) return;
@@ -162,88 +77,48 @@ async function connectWallet() {
 }
 
   async function handleToss() {
-  if (!peraWallet || !account) {
-    alert('Wallet not connected properly');
-    return;
-  }
-  
-  setLoading(true);
-  
-  try {
-    console.log('Getting location...');
-    
-    // Add timeout and better error handling for geolocation
-    const gps = await new Promise((resolve, reject) => {
-      if (!navigator.geolocation) {
-        reject(new Error('Geolocation not supported'));
-        return;
-      }
-      
-      const timeout = setTimeout(() => {
-        reject(new Error('Location request timed out'));
-      }, 10000); // 10 second timeout
-      
-      navigator.geolocation.getCurrentPosition(
-        pos => {
-          clearTimeout(timeout);
-          console.log('Got location:', pos.coords.latitude, pos.coords.longitude);
-          resolve({
-            lat: pos.coords.latitude,
-            lon: pos.coords.longitude
-          });
-        },
-        err => {
-          clearTimeout(timeout);
-          console.error('Geolocation error:', err);
-          reject(new Error(`Location error: ${err.message}`));
-        },
-        {
-          enableHighAccuracy: true,
-          timeout: 8000,
-          maximumAge: 300000 // 5 minutes
-        }
-      );
-    });
-
-    console.log('Creating transaction...');
-    console.log('Account:', account);
-    console.log('GPS:', gps);
-    
-    const txId = await tossAPod({ 
-      walletConnector: peraWallet, 
-      gps, 
-      account 
-    });
-    
-    console.log('Transaction successful:', txId);
-    alert(`Pod tossed! Transaction: ${txId}`);
-    
-    // Refresh pods list
-    const list = await fetchMyPods({ address: account });
-    setPods(list);
-    
-  } catch (err) {
-    console.error('Full error:', err);
-    
-    // Show user-friendly error messages
-    let errorMessage = 'Failed to toss pod: ';
-    
-    if (err.message.includes('Location') || err.message.includes('geolocation')) {
-      errorMessage += 'Could not access your location. Please enable location permissions and try again.';
-    } else if (err.message.includes('User rejected')) {
-      errorMessage += 'Transaction was cancelled.';
-    } else if (err.message.includes('No connected account')) {
-      errorMessage += 'Wallet connection lost. Please reconnect.';
-    } else {
-      errorMessage += err.message || 'Unknown error occurred.';
+    if (!peraWallet || !account) {
+      alert('Wallet not connected properly');
+      return;
     }
-    
-    alert(errorMessage);
-    
-  } finally {
-    setLoading(false);
+
+    setLoading(true);
+
+    try {
+      console.log('Creating transaction without GPS...');
+
+      const txId = await tossAPod({
+        walletConnector: peraWallet,
+        account
+      });
+
+      console.log('Transaction successful:', txId);
+      alert(`Pod tossed! Transaction: ${txId}`);
+
+      // Refresh pods list
+      const list = await fetchMyPods({ address: account });
+      setPods(list);
+
+    } catch (err) {
+      console.error('Full error:', err);
+
+      // Show user-friendly error messages
+      let errorMessage = 'Failed to toss pod: ';
+
+      if (err.message.includes('User rejected')) {
+        errorMessage += 'Transaction was cancelled.';
+      } else if (err.message.includes('No connected account')) {
+        errorMessage += 'Wallet connection lost. Please reconnect.';
+      } else {
+        errorMessage += err.message || 'Unknown error occurred.';
+      }
+
+      alert(errorMessage);
+
+    } finally {
+      setLoading(false);
+    }
   }
-}
 
   return (
     <div className="min-h-screen p-4">


### PR DESCRIPTION
## Summary
- remove geolocation step and toss pods without GPS data
- make tossAPod accept optional gps data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68967ac29f5883249889b8c1a7d5137b